### PR TITLE
[Fix] set the option `ret_grouped_xyz`

### DIFF
--- a/pointnet2/pointnet2_utils.py
+++ b/pointnet2/pointnet2_utils.py
@@ -388,6 +388,7 @@ class GroupAll(nn.Module):
         # type: (GroupAll, bool) -> None
         super(GroupAll, self).__init__()
         self.use_xyz = use_xyz
+        self.ret_grouped_xyz = ret_grouped_xyz
 
     def forward(self, xyz, new_xyz, features=None):
         # type: (GroupAll, torch.Tensor, torch.Tensor, torch.Tensor) -> Tuple[torch.Tensor]


### PR DESCRIPTION
The `GroupAll` module receives `ret_grouped_xyz` in its constructor but never sets it as a member. However, `self.ret_grouped_xyz` is still being used in the forward call. This PR fixes this issue.